### PR TITLE
3.4.8 / 3.4.9 update and Restore Container

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ chart/templates/tests
 
 # Temporary diffs off of marketplacetools to make things work pending Google PRs
 diff
+
+customer-solution

--- a/.gitigore
+++ b/.gitigore
@@ -1,1 +1,0 @@
-customer-solution

--- a/.gitigore
+++ b/.gitigore
@@ -1,0 +1,1 @@
+customer-solution

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ APP_NAME = neo4j
 REGISTRY = gcr.io/neo4j-k8s-marketplace-public/causal-cluster
 SOLUTION_VERSION=$(shell cat chart/Chart.yaml | grep version: | sed 's/.*: //g')
 APP_DEPLOYER_IMAGE=$(REGISTRY)/deployer:$(SOLUTION_VERSION)
-NEO4J_VERSION=3.4.4-enterprise
+NEO4J_VERSION=3.4.8-enterprise
 tools_path = ./vendor/marketplace-k8s-app-tools
 
 include $(tools_path)/crd.Makefile

--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ APP_TEST_PARAMETERS ?= { \
   "tester.image": "$(APP_TESTER_IMAGE)" \
 }
 
-app/build:: app/image .build/deployer .build/tester .build/backup
+app/build:: app/image .build/deployer .build/tester .build/backup .build/restore
 
 app/build-test:: app/build .build/tester
 
@@ -50,6 +50,8 @@ app/image:  causal-cluster/*
 	#docker push $(REGISTRY)/appropriate/curl:latest
 
 app/backup:: .build/backup
+
+app/restore:: .build/restore
 
 app/deployer:: .build/deployer
 
@@ -79,7 +81,17 @@ app/deployer:: .build/deployer
 	docker push "$(APP_TESTER_IMAGE)"
 	@date >> "$@"
 
-APP_BACKUP_IMAGE=$(REGISTRY)/backup:$(SOLUTION_VERSION)
+APP_RESTORE_IMAGE=$(REGISTRY)/restore:$(SOLUTION_VERSION)
+
+.build/restore: restore/*
+	docker build \
+		--tag "$(APP_RESTORE_IMAGE)" \
+		-f restore/Dockerfile \
+		.
+	docker push "$(APP_RESTORE_IMAGE)"
+	@date >> "$@"
+
+APP_BACKUP_IMAGE=$(REGISTRY)/restore:$(SOLUTION_VERSION)
 
 .build/backup: backup/*
 	docker build \

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ APP_NAME = neo4j
 REGISTRY = gcr.io/neo4j-k8s-marketplace-public/causal-cluster
 SOLUTION_VERSION=$(shell cat chart/Chart.yaml | grep version: | sed 's/.*: //g')
 APP_DEPLOYER_IMAGE=$(REGISTRY)/deployer:$(SOLUTION_VERSION)
-NEO4J_VERSION=3.4.8-enterprise
+NEO4J_VERSION=3.4.9-enterprise
 tools_path = ./vendor/marketplace-k8s-app-tools
 
 include $(tools_path)/crd.Makefile

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ DEPLOYER_IMAGE=gcr.io/neo4j-k8s-marketplace-public/causal-cluster/deployer:$SOLU
 APP_INSTANCE_NAME="neo4j-a$(head -c 2 /dev/urandom | base64 - | sed 's/[^A-Za-z0-9]/x/g' | tr '[:upper:]' '[:lower:]')"
 vendor/marketplace-k8s-app-tools/scripts/start.sh \
    --deployer=$DEPLOYER_IMAGE \
-   --parameters='{"name":"'$APP_INSTANCE_NAME'","namespace":"default","coreServers":"3", "cpuRequest":"100m", "memoryRequest": "1Gi", "volumeSize": "2Gi", 
+   --parameters='{"name":"'$APP_INSTANCE_NAME'","namespace":"default","coreServers":"3", "cpuRequest":"100m", "memoryRequest": "1Gi", "volumeSize": "20Gi", 
    "readReplicaServers":"1", "image": "gcr.io/neo4j-k8s-marketplace-public/causal-cluster:'$SOLUTION_VERSION'"}'
 ```
 

--- a/backup/Dockerfile
+++ b/backup/Dockerfile
@@ -10,7 +10,7 @@ RUN echo "neo4j-enterprise neo4j/question select I ACCEPT" | debconf-set-selecti
 RUN echo "neo4j-enterprise neo4j/license note" | debconf-set-selections
 
 RUN apt-get update
-RUN apt-get install -y neo4j-enterprise=1:3.4.8 google-cloud-sdk
+RUN apt-get install -y neo4j-enterprise=1:3.4.9 google-cloud-sdk
 
 RUN mkdir /data
 ADD backup/backup.sh /scripts/backup.sh

--- a/backup/Dockerfile
+++ b/backup/Dockerfile
@@ -6,12 +6,14 @@ RUN curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -
 RUN echo 'deb https://debian.neo4j.org/repo stable/' | tee -a /etc/apt/sources.list.d/neo4j.list
 RUN echo "deb http://packages.cloud.google.com/apt cloud-sdk-$(lsb_release -c -s) main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list
 
+RUN echo "neo4j-enterprise neo4j/question select I ACCEPT" | debconf-set-selections
+RUN echo "neo4j-enterprise neo4j/license note" | debconf-set-selections
+
 RUN apt-get update
-RUN apt-get install -y neo4j-enterprise=1:3.4.1 google-cloud-sdk
+RUN apt-get install -y neo4j-enterprise=1:3.4.8 google-cloud-sdk
 
 RUN mkdir /data
 ADD backup/backup.sh /scripts/backup.sh
 RUN chmod +x /scripts/backup.sh
-RUN gsutil
 
 CMD ["/scripts/backup.sh"]

--- a/bin/cypher-shell.sh
+++ b/bin/cypher-shell.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+#
+# This script executes cypher-shell on a pod chosen from the coordinating service.
+# It requires that APP_INSTANCE_NAME be defined, as is defined in deploy.sh
+#################################################################################
+if [ -z $APP_INSTANCE_NAME ] ; then
+    echo "Ensure APP_INSTANCE_NAME is defined in your environment first"
+    exit 1
+fi
+
+SOLUTION_VERSION=$(cat chart/Chart.yaml | grep version: | sed 's/.*: //g')
+
+kubectl run -it --rm cypher-shell \
+   --image=gcr.io/cloud-marketplace/neo4j-public/causal-cluster-k8s:$SOLUTION_VERSION \
+   --restart=Never \
+   --namespace=default \
+   --command -- ./bin/cypher-shell -u neo4j \
+   -p "$(kubectl get secrets $APP_INSTANCE_NAME-neo4j-secrets -o yaml | grep neo4j-password: | sed 's/.*neo4j-password: *//' | base64 --decode)" \
+   -a $APP_INSTANCE_NAME-neo4j.default.svc.cluster.local 

--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+#
+# This script executes roughly the same as what the GKE marketplace does, and
+# deploys the app with the set of parameters in the JSON below.
+##################################################################
+echo "Deploying test version"
+SOLUTION_VERSION=$(cat chart/Chart.yaml | grep version: | sed 's/.*: //g')
+DEPLOYER_IMAGE=gcr.io/neo4j-k8s-marketplace-public/causal-cluster/deployer:$SOLUTION_VERSION
+APP_INSTANCE_NAME="neo4j-a$(head -c 2 /dev/urandom | base64 - | sed 's/[^A-Za-z0-9]/x/g' | tr '[:upper:]' '[:lower:]')"
+vendor/marketplace-k8s-app-tools/scripts/start.sh \
+   --deployer=$DEPLOYER_IMAGE \
+   --parameters='{"name":"'$APP_INSTANCE_NAME'","namespace":"default","coreServers":"3", "cpuRequest":"100m", "memoryRequest": "1Gi", "volumeSize": "20Gi", 
+   "readReplicaServers":"1", "image": "gcr.io/neo4j-k8s-marketplace-public/causal-cluster:'$SOLUTION_VERSION'"}'
+
+echo "When finished, can be deleted via kubectl delete application/$APP_INSTANCE_NAME"

--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -7,9 +7,16 @@ echo "Deploying test version"
 SOLUTION_VERSION=$(cat chart/Chart.yaml | grep version: | sed 's/.*: //g')
 DEPLOYER_IMAGE=gcr.io/neo4j-k8s-marketplace-public/causal-cluster/deployer:$SOLUTION_VERSION
 APP_INSTANCE_NAME="neo4j-a$(head -c 2 /dev/urandom | base64 - | sed 's/[^A-Za-z0-9]/x/g' | tr '[:upper:]' '[:lower:]')"
+CORE_SERVERS=3
+READ_REPLICAS=1
+VOLUME_SIZE=10Gi
+CPU_REQUEST=100m
+MEM_REQUEST=1Gi
+NAMESPACE=default
+
 vendor/marketplace-k8s-app-tools/scripts/start.sh \
    --deployer=$DEPLOYER_IMAGE \
-   --parameters='{"name":"'$APP_INSTANCE_NAME'","namespace":"default","coreServers":"3", "cpuRequest":"100m", "memoryRequest": "1Gi", "volumeSize": "20Gi", 
-   "readReplicaServers":"1", "image": "gcr.io/neo4j-k8s-marketplace-public/causal-cluster:'$SOLUTION_VERSION'"}'
+   --parameters='{"name":"'$APP_INSTANCE_NAME'","namespace":"'$NAMESPACE'","coreServers":"'$CORE_SERVERS'", "cpuRequest":"'$CPU_REQUEST'", "memoryRequest": "'$MEM_REQUEST'", "volumeSize": "'$VOLUME_SIZE'", 
+   "readReplicaServers":"'$READ_REPLICAS'", "image": "gcr.io/neo4j-k8s-marketplace-public/causal-cluster:'$SOLUTION_VERSION'"}'
 
 echo "When finished, can be deleted via kubectl delete application/$APP_INSTANCE_NAME"

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -1,7 +1,7 @@
 name: neo4j
 home: https://www.neo4j.com
 version: 3.4
-appVersion: 3.4.1
+appVersion: 3.4.9
 description: Neo4j is the world's leading graph database
 icon: http://info.neo4j.com/rs/773-GON-065/images/neo4j_logo.png
 sources:

--- a/chart/templates/core-statefulset.yaml
+++ b/chart/templates/core-statefulset.yaml
@@ -88,8 +88,8 @@ spec:
           name: browserhttps
         - containerPort: 7687
           name: bolt
-        securityContext:
-          privileged: true
+        # securityContext:
+        #   privileged: true
         volumeMounts:
         - name: datadir
           mountPath: "{{ .Values.volumeMountPath }}"

--- a/chart/templates/core-statefulset.yaml
+++ b/chart/templates/core-statefulset.yaml
@@ -131,6 +131,11 @@ spec:
       volumes:
         - name: plugins
           emptyDir: {}
+{{- if .Values.maintenanceServiceKeySecret }}
+        - name: "{{ .Values.maintenanceServiceKeySecret }}"
+          secret:
+            secretName: "{{ .Values.maintenanceServiceKeySecret }}"
+{{- end }}
   volumeClaimTemplates:
     - metadata:
         name: datadir

--- a/chart/templates/core-statefulset.yaml
+++ b/chart/templates/core-statefulset.yaml
@@ -26,12 +26,16 @@ spec:
         env:
           - name: NEO4J_ACCEPT_LICENSE_AGREEMENT
             value: "{{ .Values.acceptLicenseAgreement }}"
-          - name: NEO4J_dbms_mode
-            value: CORE
           - name: NUMBER_OF_CORES
             value: "{{ .Values.coreServers }}"
           - name: AUTH_ENABLED
             value: "{{ .Values.authEnabled }}"
+{{- if lt .Values.coreServers 3.0 }}
+          - name: NEO4J_dbms_mode
+            value: SINGLE
+{{ else }}
+          - name: NEO4J_dbms_mode
+            value: CORE
           - name: NEO4J_causal__clustering_discovery__type
             value: DNS
           - name: NEO4J_causal__clustering_minimum__core__cluster__size__at__formation
@@ -40,6 +44,7 @@ spec:
             value: "3"
           - name: NEO4J_causal__clustering_initial__discovery__members
             value: "{{ template "neo4j.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:5000"
+{{- end }}
           {{- if .Values.authEnabled }}
           - name: NEO4J_SECRETS_PASSWORD
             valueFrom:

--- a/chart/templates/readreplicas-statefulset.yaml
+++ b/chart/templates/readreplicas-statefulset.yaml
@@ -4,7 +4,12 @@ metadata:
   name: "{{ template "neo4j.replica.fullname" . }}"
 spec:
   serviceName: {{ template "neo4j.name" . }}-readreplica
+{{- if lt .Values.coreServers 3.0 }}
+  # Replicas are only meaningful if we have a core set.  Single mode operations here.
+  replicas: 0
+{{ else }}  
   replicas: {{ .Values.readReplicaServers }}
+{{- end }}
   selector:
     matchLabels:
       release: {{ .Values.name | quote }}

--- a/chart/templates/readreplicas-statefulset.yaml
+++ b/chart/templates/readreplicas-statefulset.yaml
@@ -113,6 +113,11 @@ spec:
       volumes:
         - name: plugins
           emptyDir: {}
+{{- if .Values.maintenanceServiceKeySecret }}
+        - name: "{{ .Values.maintenanceServiceKeySecret }}"
+          secret:
+            secretName: "{{ .Values.maintenanceServiceKeySecret }}"
+{{- end }}
   volumeClaimTemplates:
     - metadata:
         name: datadir

--- a/chart/templates/readreplicas-statefulset.yaml
+++ b/chart/templates/readreplicas-statefulset.yaml
@@ -79,8 +79,8 @@ spec:
           name: browserhttps
         - containerPort: 7687
           name: bolt
-        securityContext:
-          privileged: true
+        # securityContext:
+        #   privileged: true
         volumeMounts:
         - name: datadir
           mountPath: "{{ .Values.volumeMountPath }}"

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -26,26 +26,41 @@ authEnabled: true
 ## Defaults to a random 10-character alphanumeric string if not set and authEnabled is true
 # neo4jPassword:
 
+# Uncomment this and set it if you want to pair an existing secret service key
+# maintenanceServiceKeySecret=restore-service-key
+
 ######################
 #### CORE SERVERS  ###
 ######################
 coreServers: 3
 coreSidecarContainers: []
 
-## init containers to run before the Neo4j replica pod e.g. to install plugins
-# - name: init-plugins
-#   image: "appropriate/curl:latest"
-#   imagePullPolicy: "IfNotPresent"
-#   volumeMounts:
-#   - name: plugins
-#     mountPath: /plugins
-#   command:
-#     - "/bin/sh"
-#     - "-c"
-#     - |
-#       curl -L https://github.com/neo4j-contrib/neo4j-apoc-procedures/releases/download/3.2.0.3/apoc-3.2.0.3-all.jar -O
-#       cp apoc-3.2.0.3-all.jar /plugins/
 coreInitContainers: []
+#####################################################################
+# ---> EXAMPLE OF HOW TO SETUP initContainers for restore.
+#####################################################################
+#  - name: restore-from-file
+#    image: gcr.io/neo4j-k8s-marketplace-public/causal-cluster/restore:3.4
+#    imagePullPolicy: Always
+#    volumeMounts:
+#    - name: datadir
+#      mountPath: /data
+#    - name: restore-service-key
+#      mountPath: /auth
+#    env:
+#    - name: BUCKET
+#      value: gs://tmp-k8s-backup-storage
+#    - name: BACKUP_NAME
+#      value: TrumpTweets-2018-07-02-12:44:02.tar.gz
+#    - name: GOOGLE_APPLICATION_CREDENTIALS
+#      value: /auth/credentials.json
+#    - name: FORCE_OVERWRITE
+#      value: "false"
+#####################################################################
+# EXAMPLE OF HOW TO SETUP initContainers for custom plugin install.
+# do not use this particular one, because APOC is already installed, it is
+# just provided as an example.
+#####################################################################
 #  - name: init-plugins
 #    image: "gcr.io/neo4j-k8s-marketplace-public/causal-cluster/appropriate/curl"
 #    imagePullPolicy: "IfNotPresent"
@@ -94,18 +109,6 @@ readReplicaServers: 0
 # - name: EXTRA_VAR_2
 #   value: extra-var-value-2
 readReplicaInitContainers: []
-#  - name: init-plugins
-#    image: "gcr.io/neo4j-k8s-marketplace-public/causal-cluster/appropriate/curl"
-#    imagePullPolicy: "IfNotPresent"
-#    volumeMounts:
-#    - name: plugins
-#      mountPath: /plugins
-#    command:
-#      - "/bin/sh"
-#      - "-c"
-#      - |
-#        curl -L https://github.com/neo4j-contrib/neo4j-apoc-procedures/releases/download/3.4.0.1/apoc-3.4.0.1-all.jar -O
-#        cp apoc-3.4.0.1-all.jar /plugins/
 
 cpuRequest: 200m
 cpuLimit: 8

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -10,7 +10,7 @@ image: "gcr.io/neo4j-k8s-marketplace-public/causal-cluster:3.4"
 # Version for the solution container
 imageTag: "3.4"
 # Neo4j version the solution container is based on.
-neo4jVersion: "3.4.1"
+neo4jVersion: "3.4.9"
 ubbAgentImage: "gcr.io/neo4j-k8s-marketplace-public/causal-cluster/ubbagent:3.4"
 imagePullPolicy: "Always"
 # imagePullSecret: registry-secret
@@ -27,7 +27,7 @@ authEnabled: true
 # neo4jPassword:
 
 # Uncomment this and set it if you want to pair an existing secret service key
-# maintenanceServiceKeySecret=restore-service-key
+# maintenanceServiceKeySecret: "restore-service-key"
 
 ######################
 #### CORE SERVERS  ###
@@ -48,14 +48,15 @@ coreInitContainers: []
 #    - name: restore-service-key
 #      mountPath: /auth
 #    env:
-#    - name: BUCKET
-#      value: gs://tmp-k8s-backup-storage
-#    - name: BACKUP_NAME
-#      value: TrumpTweets-2018-07-02-12:44:02.tar.gz
+#    - name: REMOTE_BACKUPSET
+#      value: gs://neo4j-database-backups/meetup-dataset-dirformat
+#    - name: BACKUP_SET_DIR
+#      value: meetup-dataset-backup
 #    - name: GOOGLE_APPLICATION_CREDENTIALS
 #      value: /auth/credentials.json
+#    # CAUTION: Read documentation before proceeding with this flag.
 #    - name: FORCE_OVERWRITE
-#      value: "false"
+#      value: "true"
 #####################################################################
 # EXAMPLE OF HOW TO SETUP initContainers for custom plugin install.
 # do not use this particular one, because APOC is already installed, it is
@@ -108,6 +109,10 @@ readReplicaServers: 0
 #   value: extra-var-value-1
 # - name: EXTRA_VAR_2
 #   value: extra-var-value-2
+
+# See above for examples on how to restore recent backups to read replicas.
+# You need to configure this separately from core member init containers, to permit
+# different configuration to apply to each node set.
 readReplicaInitContainers: []
 
 cpuRequest: 200m

--- a/restore/Dockerfile
+++ b/restore/Dockerfile
@@ -10,7 +10,7 @@ RUN echo "neo4j-enterprise neo4j/question select I ACCEPT" | debconf-set-selecti
 RUN echo "neo4j-enterprise neo4j/license note" | debconf-set-selections
 
 RUN apt-get update
-RUN apt-get install -y neo4j-enterprise=1:3.4.9 google-cloud-sdk
+RUN apt-get install -y neo4j-enterprise=1:3.4.9 google-cloud-sdk unzip
 
 RUN mkdir /data
 ADD restore/restore.sh /scripts/restore.sh

--- a/restore/Dockerfile
+++ b/restore/Dockerfile
@@ -1,0 +1,19 @@
+FROM launcher.gcr.io/google/debian9
+RUN apt-get update
+RUN apt-get install -y bash curl wget gnupg apt-transport-https apt-utils lsb-release
+RUN wget -O - https://debian.neo4j.org/neotechnology.gpg.key | apt-key add -
+RUN curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -
+RUN echo 'deb https://debian.neo4j.org/repo stable/' | tee -a /etc/apt/sources.list.d/neo4j.list
+RUN echo "deb http://packages.cloud.google.com/apt cloud-sdk-$(lsb_release -c -s) main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list
+
+RUN echo "neo4j-enterprise neo4j/question select I ACCEPT" | debconf-set-selections
+RUN echo "neo4j-enterprise neo4j/license note" | debconf-set-selections
+
+RUN apt-get update
+RUN apt-get install -y neo4j-enterprise=1:3.4.8 google-cloud-sdk
+
+RUN mkdir /data
+ADD restore/restore.sh /scripts/restore.sh
+RUN chmod +x /scripts/restore.sh
+
+CMD ["/scripts/restore.sh"]

--- a/restore/Dockerfile
+++ b/restore/Dockerfile
@@ -10,7 +10,7 @@ RUN echo "neo4j-enterprise neo4j/question select I ACCEPT" | debconf-set-selecti
 RUN echo "neo4j-enterprise neo4j/license note" | debconf-set-selections
 
 RUN apt-get update
-RUN apt-get install -y neo4j-enterprise=1:3.4.8 google-cloud-sdk
+RUN apt-get install -y neo4j-enterprise=1:3.4.9 google-cloud-sdk
 
 RUN mkdir /data
 ADD restore/restore.sh /scripts/restore.sh

--- a/restore/README-RESTORE.md
+++ b/restore/README-RESTORE.md
@@ -30,6 +30,16 @@ kubectl create secret generic restore-service-key \
    --from-file=credentials.json=$MY_SERVICE_ACCOUNT_KEY
 ```
 
+In `values.yaml`, then configure the secret you set here like so:
+
+```
+# maintenanceServiceKeySecret=restore-service-key
+```
+
+This setting allows the core and read replica nodes to access that service key
+as a volume.  That volume being present within the containers is necessary for the
+next step.
+
 ### Configure the initContainer for Core and Read Replica Nodes
 
 Finally, specify the initContainer like this, in `values.yaml`.
@@ -59,6 +69,8 @@ coreInitContainers:
      - name: FORCE_OVERWRITE
        value: "false"
 ```
+
+Notice that we're mounting the secret at the `/auth` path and then passing our application credentials as a file within that path.  This is what permits shell tools to access your google cloud storage resources.
 
 This snippet above creates the initContainer just for core nodes.  It's strongly recommended you do the same for `readReplicaInitContainers` if you are using read replicas. If you restore only to core nodes and not to read replicas, when they start
 the core nodes will replicate the data to the read replicas.   This will work just fine, but may result in longer startup times and much more bandwidth.

--- a/restore/README-RESTORE.md
+++ b/restore/README-RESTORE.md
@@ -15,11 +15,6 @@ the `backup` container in this same code repository.  We recommend you use that 
 inspect the `restore.sh` script, because it needs to make certain assumptions about
 directory structure that come out of archived backups in order to restore properly.
 
-## Using the Restore Container
-
-Code for the restore container can be found in this directory, and can be built as
-a docker container directly, and pushed to any registry as needed.
-
 ### Create a service key secret to access cloud storage
 
 First you want to create a kubernetes secret that contains the content of your account service key.  This key must have permissions to access the bucket and backup set that you're trying to restore. 
@@ -97,6 +92,18 @@ persistent volumes.  The default is false; if data already exists on the drive, 
 With the initContainer in place and properly configured, simply deploy a new cluster 
 using the regular approach.  Prior to start, the restore will happen, and when the 
 cluster comes live, it will be populated with the data.
+
+## Limitations
+
+As of Neo4j 3.4 series, data backups do not include authorization information for your cluster.
+That is, usernames/passwords associated with the graph are not included in the backup, and hence
+are not restored when you restore.
+
+This is something to be aware of; when launching a cluster typically you're providing startup auth
+information and separate configuration anyway.  If you create users, groups, and roles you may want
+to separately take copies of the auth files so that they can be restored when your cluster starts up.
+Alternatively, users may configure their systems to use LDAP providers in which case there is no need
+to backup any auth information.
 
 ## Ongoing Maintenance
 

--- a/restore/README-RESTORE.md
+++ b/restore/README-RESTORE.md
@@ -3,30 +3,76 @@
 This directory contains files necessary for restoring Neo4j Docker containers
 from google storage, or local files placed on the volume.
 
-See restore.yaml for an example.   
+## Approach
 
-## Required Parameters
+The restore container is used as an `initContainer` in the main cluster.  Prior to
+a node in the Neo4j cluster starting, the restore container copies down the backup
+set, and restores it into place.  When the initContainer terminates, the regular
+Neo4j docker instance starts, and picks up where the backup left off.
 
-- `GOOGLE_APPLICATION_CREDENTIALS` - path to a file with a JSON service account key (see credentials below)
-- `BUCKET` the URL of the bucket, of the form `gs://my-bucket` where the backup set resides.
-- `BACKUP_NAME` path to a file (or uncompressed directory) within the bucket that contains the
-backup files.  Example:  `mydata-backup-2018-09-01.tar.gz`
+This container is primarily tested against the backup .tar.gz archives produced by
+the `backup` container in this same code repository.  We recommend you use that approach.  If you tar/gz your own backups using a different approach, be careful to
+inspect the `restore.sh` script, because it needs to make certain assumptions about
+directory structure that come out of archived backups in order to restore properly.
 
-The restore container can detect .tar.gz and .zip compressed backups and deal with them appropriately, as well as uncompressed directory backup sets.
+## Using the Restore Container
 
-## Credentials
+Code for the restore container can be found in this directory, and can be built as
+a docker container directly, and pushed to any registry as needed.
 
-First you want to create a kubernetes secret that contains your account service key, like this:
+### Create a service key secret to access cloud storage
+
+First you want to create a kubernetes secret that contains the content of your account service key.  This key must have permissions to access the bucket and backup set that you're trying to restore. 
 
 ```
-MY_SERVICE_ACCOUNT_KEY=$HOME/.google/neo4j-k8s-marketplace-public-ad35bd86462f.json
+MY_SERVICE_ACCOUNT_KEY=$HOME/.google/my-service-key.json
 kubectl create secret generic restore-service-key \
    --from-file=credentials.json=$MY_SERVICE_ACCOUNT_KEY
 ```
 
-Then in the initContainer, you want to map use a volume mount to connect restore-service-key to /auth, and then you can simply specify:
+### Configure the initContainer for Core and Read Replica Nodes
 
-`GOOGLE_APPLICATION_CREDENTIALS=/auth/credentials.json`
+Finally, specify the initContainer like this, in `values.yaml`.
+
+Important:
+* Ensure that the volume mount to /auth matches the secret name you created above.
+* Ensure that your BUCKET, BACKUP_NAME, and GOOGLE_APPLICATION_CREDENTIALS are
+set correctly given the way you created your secret.
+
+```
+coreInitContainers: 
+   - name: restore-from-file
+     image: gcr.io/neo4j-k8s-marketplace-public/causal-cluster/restore:3.4
+     imagePullPolicy: Always
+     volumeMounts:
+     - name: datadir
+       mountPath: /data
+     - name: restore-service-key
+       mountPath: /auth
+     env:
+     - name: BUCKET
+       value: gs://my-google-storage-bucket
+     - name: BACKUP_NAME
+       value: my-backup-set.tar.gz
+     - name: GOOGLE_APPLICATION_CREDENTIALS
+       value: /auth/credentials.json
+     - name: FORCE_OVERWRITE
+       value: "false"
+```
+
+This snippet above creates the initContainer just for core nodes.  It's strongly recommended you do the same for `readReplicaInitContainers` if you are using read replicas. If you restore only to core nodes and not to read replicas, when they start
+the core nodes will replicate the data to the read replicas.   This will work just fine, but may result in longer startup times and much more bandwidth.
+
+## Parameters
+
+- `GOOGLE_APPLICATION_CREDENTIALS` - path to a file with a JSON service account key (see credentials below)
+- `BUCKET` the URL of the bucket, of the form `gs://my-bucket` where the backup set resides.
+- `BACKUP_NAME` path to a file (or uncompressed directory) within the bucket that contains the backup files.  Example:  `mydata-backup-2018-09-01.tar.gz`
+- `PURGE_ON_COMPLETE` (defaults to false/no).  If this is set to the value "true", the restore process will remove the restore artifacts from disk.  Otherwise, they
+will be left in place.  This is useful for debugging restores, to see what was
+copied down from cloud storage and how it was expanded.
+
+The restore container can detect .tar.gz and .zip compressed backups and deal with them appropriately, as well as uncompressed directory backup sets.
 
 ## Optional Parameters
 
@@ -34,4 +80,18 @@ Then in the initContainer, you want to map use a volume mount to connect restore
 destroy any existing data that is on the volume.  Take care when using this in combination with
 persistent volumes.  The default is false; if data already exists on the drive, the restore operation will likely fail but preserve your data.
 
+## Running the Restore
 
+With the initContainer in place and properly configured, simply deploy a new cluster 
+using the regular approach.  Prior to start, the restore will happen, and when the 
+cluster comes live, it will be populated with the data.
+
+## Ongoing Maintenance
+
+In general we'd recommend taking regular full backups, and restoring from those.
+
+## Limitations
+
+- Container has not yet been tested with incremental backups
+- For the time being, only google storage as a cloud storage option is implemented, 
+but adapting this approach to S3 or other storage should be fairly straightforward with modifications to `restore.sh`

--- a/restore/README-RESTORE.md
+++ b/restore/README-RESTORE.md
@@ -35,6 +35,9 @@ This setting allows the core and read replica nodes to access that service key
 as a volume.  That volume being present within the containers is necessary for the
 next step.
 
+If this service key secret is not in place, the auth information will not be able to be mounted as
+a volume in the initContainer, and your pods may get stuck/hung at "ContainerCreating" phase.
+
 ### Configure the initContainer for Core and Read Replica Nodes
 
 Finally, specify the initContainer like this, in `values.yaml`.
@@ -86,6 +89,19 @@ The restore container can detect .tar.gz and .zip compressed backups and deal wi
 - `FORCE_OVERWRITE` if this is the value "true", then the restore process will overwrite and
 destroy any existing data that is on the volume.  Take care when using this in combination with
 persistent volumes.  The default is false; if data already exists on the drive, the restore operation will likely fail but preserve your data.
+
+**Warnings**
+
+A common way you might deploy Neo4j would be restore from last backup when a container initializes.  This would be good for a cluster, because it would minimize how much catch-up
+is needed when a node is launched.  Any difference between the last backup and the rest of the
+cluster would be provided via catch-up.
+
+For single nodes, take extreme care here.  If a node crashes, and you automatically restore from
+backup, and force-overwrite what was previously on the disk, you will lose any data that the
+database captured between when the last backup was taken, and when the crash happened.  As a
+result, for single node instances of Neo4j you should either perform restores manually when you
+need them, or you should keep a very regular backup schedule to minimize this data loss.  If data
+loss is under no circumstances acceptable, do not automate restores for single node deploys.
 
 ## Running the Restore
 

--- a/restore/README-RESTORE.md
+++ b/restore/README-RESTORE.md
@@ -75,9 +75,9 @@ the core nodes will replicate the data to the read replicas.   This will work ju
 - `GOOGLE_APPLICATION_CREDENTIALS` - path to a file with a JSON service account key (see credentials below)
 - `REMOTE_BACKUPSET` the URL of the backupset, of the form `gs://my-bucket/my-backup.tar.gz` where the backup set resides.
 - `BACKUP_SET_DIR` - (optional).  If you used the backup container that comes with this repo, then this is not needed.  If you made your own backup, this should contain the name of the directory that the compressed backup set expands to.  This is intended to handle relative paths within the compressed set.  For example if your backup set `foo.tar.gz` decompresses to `myData/mySet/*` files, then you would set `BACKUP_SET_DIR=myData/mySet` (the relative path) so that the restore utility knows the right directory to point at after the set is uncompressed.
-- `PURGE_ON_COMPLETE` (defaults to false/no).  If this is set to the value "true", the restore process will remove the restore artifacts from disk.  Otherwise, they
-will be left in place.  This is useful for debugging restores, to see what was
-copied down from cloud storage and how it was expanded.
+- `PURGE_ON_COMPLETE` (defaults to true).  If this is set to the value "true", the restore process will remove the restore artifacts from disk.  With any other 
+value, they will be left in place.  This is useful for debugging restores, to 
+see what was copied down from cloud storage and how it was expanded.
 
 The restore container can detect .tar.gz and .zip compressed backups and deal with them appropriately, as well as uncompressed directory backup sets.
 

--- a/restore/README-RESTORE.md
+++ b/restore/README-RESTORE.md
@@ -55,10 +55,10 @@ coreInitContainers:
      - name: restore-service-key
        mountPath: /auth
      env:
-     - name: BUCKET
-       value: gs://my-google-storage-bucket
-     - name: BACKUP_NAME
-       value: my-backup-set.tar.gz
+     - name: REMOTE_BACKUPSET
+       value: gs://my-google-storage-bucket/my-backupset.tar.gz
+     - name: BACKUP_SET_DIR
+       value: my-backup-set
      - name: GOOGLE_APPLICATION_CREDENTIALS
        value: /auth/credentials.json
      - name: FORCE_OVERWRITE
@@ -73,8 +73,8 @@ the core nodes will replicate the data to the read replicas.   This will work ju
 ## Parameters
 
 - `GOOGLE_APPLICATION_CREDENTIALS` - path to a file with a JSON service account key (see credentials below)
-- `BUCKET` the URL of the bucket, of the form `gs://my-bucket` where the backup set resides.
-- `BACKUP_NAME` path to a file (or uncompressed directory) within the bucket that contains the backup files.  Example:  `mydata-backup-2018-09-01.tar.gz`
+- `REMOTE_BACKUPSET` the URL of the backupset, of the form `gs://my-bucket/my-backup.tar.gz` where the backup set resides.
+- `BACKUP_SET_DIR` - (optional).  If you used the backup container that comes with this repo, then this is not needed.  If you made your own backup, this should contain the name of the directory that the compressed backup set expands to.  This is intended to handle relative paths within the compressed set.  For example if your backup set `foo.tar.gz` decompresses to `myData/mySet/*` files, then you would set `BACKUP_SET_DIR=myData/mySet` (the relative path) so that the restore utility knows the right directory to point at after the set is uncompressed.
 - `PURGE_ON_COMPLETE` (defaults to false/no).  If this is set to the value "true", the restore process will remove the restore artifacts from disk.  Otherwise, they
 will be left in place.  This is useful for debugging restores, to see what was
 copied down from cloud storage and how it was expanded.

--- a/restore/README-RESTORE.md
+++ b/restore/README-RESTORE.md
@@ -1,0 +1,37 @@
+# Restoring Neo4j Containers
+
+This directory contains files necessary for restoring Neo4j Docker containers
+from google storage, or local files placed on the volume.
+
+See restore.yaml for an example.   
+
+## Required Parameters
+
+- `GOOGLE_APPLICATION_CREDENTIALS` - path to a file with a JSON service account key (see credentials below)
+- `BUCKET` the URL of the bucket, of the form `gs://my-bucket` where the backup set resides.
+- `BACKUP_NAME` path to a file (or uncompressed directory) within the bucket that contains the
+backup files.  Example:  `mydata-backup-2018-09-01.tar.gz`
+
+The restore container can detect .tar.gz and .zip compressed backups and deal with them appropriately, as well as uncompressed directory backup sets.
+
+## Credentials
+
+First you want to create a kubernetes secret that contains your account service key, like this:
+
+```
+MY_SERVICE_ACCOUNT_KEY=$HOME/.google/neo4j-k8s-marketplace-public-ad35bd86462f.json
+kubectl create secret generic restore-service-key \
+   --from-file=credentials.json=$MY_SERVICE_ACCOUNT_KEY
+```
+
+Then in the initContainer, you want to map use a volume mount to connect restore-service-key to /auth, and then you can simply specify:
+
+`GOOGLE_APPLICATION_CREDENTIALS=/auth/credentials.json`
+
+## Optional Parameters
+
+- `FORCE_OVERWRITE` if this is the value "true", then the restore process will overwrite and
+destroy any existing data that is on the volume.  Take care when using this in combination with
+persistent volumes.  The default is false; if data already exists on the drive, the restore operation will likely fail but preserve your data.
+
+

--- a/restore/restore.sh
+++ b/restore/restore.sh
@@ -151,7 +151,7 @@ neo4j-admin restore \
 
 RESTORE_EXIT_CODE=$?
 
-if [ RESTORE_EXIT_CODE -ne 0 ]; then 
+if [ "$RESTORE_EXIT_CODE" -ne 0 ]; then 
     echo "Restore process failed; will not continue"
     exit $RESTORE_EXIT_CODE
 fi

--- a/restore/restore.sh
+++ b/restore/restore.sh
@@ -1,0 +1,149 @@
+#!/bin/bash
+
+if [ -z $BUCKET ]; then
+    echo "You must specify a BUCKET address such as gs://my-backups/"
+    exit 1
+fi
+
+if [ -z $BACKUP_NAME ] ; then
+    echo "You must specify a BACKUP_NAME such as my-data.tar.gz"
+    exit 1
+fi
+
+if [ -z $PURGE_ON_COMPLETE ]; then
+    PURGE_ON_COMPLETE=false
+fi
+
+# Pass the force flag to the restore operation, which will overwrite
+# whatever is there, if and only if FORCE_OVERWRITE=true.
+if [ "$FORCE_OVERWRITE" = true ]; then
+    echo "We will be force-overwriting any data present"
+    FORCE_FLAG="--force"
+else
+    # Pass no flag in any other setup.
+    echo "We will not force-overwrite data if present"
+    FORCE_FLAG=""
+fi
+
+if [ -z $HEAP_SIZE ] ; then
+    HEAP_SIZE=2G
+fi
+
+if [ -z $PAGE_CACHE ]; then
+    PAGE_CACHE=4G
+fi
+
+echo "Activating google credentials before beginning"
+echo $GOOGLE_APPLICATION_CREDENTIALS
+ls -l $GOOGLE_APPLICATION_CREDENTIALS
+cat $GOOGLE_APPLICATION_CREDENTIALS
+gcloud auth activate-service-account --key-file "$GOOGLE_APPLICATION_CREDENTIALS"
+
+if [ $? -ne 0 ] ; then
+    echo "Credentials failed; no way to copy from google."
+    echo "Ensure GOOGLE_APPLICATION_CREDENTIALS is appropriately set."
+fi
+
+echo "=============== Neo4j Restore ==============================="
+echo "Beginning restore from $BACKUP_NAME to /data/"
+echo "Using heap size $HEAP_SIZE and page cache $PAGE_CACHE"
+echo "From google storage bucket $BUCKET using credentials located at $GOOGLE_APPLICATION_CREDENTIALS"
+echo "============================================================"
+
+BACKUPSET_ROOT=/data/backupset
+RESTORE_FROM=/data/backupset
+
+echo "Making restore directory"
+mkdir -p /data/backupset
+
+echo "Copying $BUCKET/$BACKUP_NAME -> $RESTORE_FROM"
+
+# By copying recursively, the user can specify a dir with an uncompressed
+# backup if preferred. The -m flag downloads in parallel if possible.
+gsutil cp -r "$BUCKET/$BACKUP_NAME" "$RESTORE_FROM"
+
+echo "Backup size pre-uncompress:"
+du -hs "$RESTORE_FROM"
+ls -l "$RESTORE_FROM"
+
+# Important note!  If you have a backup name that is "foo.tar.gz" or 
+# foo.zip, we need to assume that this unarchives to a directory called
+# foo, as neo4j backup sets are directories.  So we'll remove the suffix
+# after unarchiving and use that as the actual backup target.
+if [[ $BACKUP_NAME =~ \.tar\.gz$ ]] ; then
+    echo "Untarring backupset"
+    cd "$RESTORE_FROM" && tar --force-local -zxvf "$BACKUP_NAME"
+
+    if [ $? -ne 0 ] ; then
+        echo "Failed to unarchive target backup set"
+        exit 1
+    fi
+
+    # foo.tar.gz untars/zips to a directory called foo.
+    UNTARRED_BACKUP_DIR=${BACKUP_NAME%.tar.gz}
+    RESTORE_FROM="$RESTORE_FROM/data/$UNTARRED_BACKUP_DIR"
+elif [[ $BACKUP_NAME =~ \.zip$ ]] ; then
+    echo "Unzipping backupset"
+    cd "$RESTORE_FROM" && unzip "$BACKUP_NAME"
+    
+    if [ $? -ne 0 ]; then 
+        echo "Failed to unzip target backup set"
+        exit 1
+    fi
+
+    # Remove file extension, get to directory name
+    UNZIPPED_BACKUP_DIR=${BACKUP_NAME%.zip}
+    RESTORE_FROM="$RESTORE_FROM/data/$UNZIPPED_BACKUP_DIR"
+else
+    echo "This backup $BACKUP_NAME looks uncompressed."
+    RESTORE_FROM="$RESTORE_FROM/$BACKUP_NAME"
+fi
+
+echo "Set to restore from $RESTORE_FROM"
+echo "Post compress backup size:"
+du -hs "$RESTORE_FROM"
+ls "$RESTORE_FROM"
+
+cd /data && \
+echo "Dry-run command"
+echo neo4j-admin restore \
+    --from="$RESTORE_FROM" \
+    --database=graph.db $FORCE_FLAG
+
+echo "Volume mounts and sizing"
+df -h
+
+echo "Now restoring"
+neo4j-admin restore \
+    --from="$RESTORE_FROM" \
+    --database=graph.db $FORCE_FLAG
+
+RESTORE_EXIT_CODE=$?
+
+echo "Restore process complete with exit code $RESTORE_EXIT_CODE"
+
+echo "Rehoming database"
+echo "Restored to:"
+ls -lR /var/lib/neo4j/data/databases
+
+# neo4j-admin restore puts the DB in the wrong place, it needs to be re-homed
+# for docker.
+mkdir /data/databases
+mv /var/lib/neo4j/data/databases/graph.db /data/databases/
+
+# Modify permissions/group, because we're running as root.
+chown -R neo4j /data/databases
+chgrp -R neo4j /data/databases
+
+echo "Final permissions"
+ls -al /data/databases/graph.db
+
+echo "Final size"
+du -ms /data/databases/graph.db
+
+if [ "$PURGE_ON_COMPLETE" = true ] ; then
+    echo "Purging backupset from disk"
+    rm -rf "$BACKUPSET_ROOT"
+fi
+
+exit $RESTORE_EXIT_CODE

--- a/schema.yaml
+++ b/schema.yaml
@@ -14,10 +14,10 @@ properties:
     x-google-marketplace:
       type: IMAGE
   coreServers:
-    title: Server replicas to use
+    title: Core servers to use
     type: integer
     default: 3
-    minimum: 3
+    minimum: 1
     maximum: 9
   readReplicaServers:
     title: Read Replicas

--- a/setup-k8s.sh
+++ b/setup-k8s.sh
@@ -7,7 +7,7 @@ CLUSTER=lab
 ZONE=us-central1-a
 NODES=3
 API=beta
-NEO4J_VERSION=3.4.8-enterprise
+NEO4J_VERSION=3.4.9-enterprise
 
 gcloud beta container clusters create $CLUSTER \
     --zone "$ZONE" \

--- a/setup-k8s.sh
+++ b/setup-k8s.sh
@@ -7,7 +7,7 @@ CLUSTER=lab
 ZONE=us-central1-a
 NODES=3
 API=beta
-NEO4J_VERSION=3.4.4-enterprise
+NEO4J_VERSION=3.4.8-enterprise
 
 gcloud beta container clusters create $CLUSTER \
     --zone "$ZONE" \

--- a/user-guide/USER-GUIDE.md
+++ b/user-guide/USER-GUIDE.md
@@ -155,6 +155,13 @@ Provided with this distribution is a method of backing up a neo4j instance to Go
 
 For full details on all aspects of Backup and Restore, please consult the [Neo4j documentation on backups](https://neo4j.com/docs/operations-manual/current/backup/?ref=googlemarketplace).
 
+### Restore
+
+This repo contains a restore directory with a container that can restore a Neo4j backup
+to the pod before it starts.  Generally the restore runs as an initContainer.  You will
+need a backup set stored in google storage, and a service key with access to the
+relevant bucket.
+
 ### Image Updates
 
 This version of Neo4j on GKE tracks the 3.4 release series of Neo4j.  As such, periodic updates may be provided which will increase the patch level release that is underlying causal cluster, but at no time will any non-backwards compatible image updates be introduced.


### PR DESCRIPTION
- Update neo4j to 3.4.9
- Add new restore container along with documentation on how to use it.
- Remove securityContext and need for privileges (unused)
- Added support for single node deploys (coreServers=1)
- Better documentation
